### PR TITLE
Cache Lua scripts in Redis to minimize traffic over the network

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ### 0.0.3 (Unreleased)
 
+  * Lox now attempts to cache its Lua scripts inside of Redis. This eliminates the need to send the entire script to Redis for each evaluation; now Lox need only send the SHA hash of the script each time.
+
 ### 0.0.2 (February 11, 2015)
 
   * Replaced Redis transactions (WATCH/MULTI/EXEC) with a Lua script for lock acquisition. This fixed a bug where transaction behavior could become undefined since we were using a single Redis connection across multiple transactions.

--- a/lib/lock.js
+++ b/lib/lock.js
@@ -2,7 +2,8 @@ var _ = require('underscore');
 var _s = require('underscore.string');
 var uuid = require('node-uuid');
 var async = require('async');
-var client = require('./redis-client');
+var redis = require('./redis-client');
+var client = redis.client;
 var lua = require('./lua');
 
 /**
@@ -42,9 +43,17 @@ exports.reapLock = function(key, callback) {
  */
 exports.acquireLock = function(key, maximumLocks, ttlSeconds, callback) {
   var lockId = uuid.v1();
-  client.eval(lua.acquire_lock, 1, key, lockId, maximumLocks, ttlSeconds, function(err, response) {
+  async.waterfall([
+    function(cb) { return redis.ensureScript(client, lua.acquire_lock, cb); },
+    function(cb) {
+      client.eval(lua.acquire_lock, 1, key, lockId, maximumLocks, ttlSeconds, function(err, response) {
+        if (err) { return cb(err, null); }
+        return cb(null, response ? lockId : null);
+      });
+    }
+  ], function(err, lockId) {
     if (err) { return callback(err, null); }
-    return callback(null, response ? lockId : null);
+    return callback(null, lockId);
   });
 };
 
@@ -66,12 +75,19 @@ exports.acquireMultipleLocks = function(keys, maximumLocks, ttlSeconds, callback
   var lockIdsPipeDelimited = lockIds.join('|');
   var evalArgs = _.flatten([lua.acquire_multiple_locks, keys.length, keys, lockIdsPipeDelimited, maximumLocks, ttlSeconds]);
 
-  client.eval(evalArgs, function(err, response) {
+  async.waterfall([
+    function(cb) { return redis.ensureScript(client, lua.acquire_multiple_locks, cb); },
+    function(cb) {
+      client.eval(evalArgs, function(err, response) {
+        if (err) { return cb(err, null); }
+        var lockIdMapping = _.object(keys, lockIds);
+        return cb(null, response ? lockIdMapping : null);
+      });
+    }
+  ], function(err, lockIdMapping) {
     if (err) { return callback(err, null); }
-    var lockIdMapping = _.object(keys, lockIds);
-    return callback(null, response ? lockIdMapping : null);
+    return callback(null, lockIdMapping);
   });
-
 };
 
 /**

--- a/lib/lock.js
+++ b/lib/lock.js
@@ -51,10 +51,7 @@ exports.acquireLock = function(key, maximumLocks, ttlSeconds, callback) {
         return cb(null, response ? lockId : null);
       });
     }
-  ], function(err, lockId) {
-    if (err) { return callback(err); }
-    return callback(null, lockId);
-  });
+  ], callback);
 };
 
 
@@ -84,10 +81,7 @@ exports.acquireMultipleLocks = function(keys, maximumLocks, ttlSeconds, callback
         return cb(null, response ? lockIdMapping : null);
       });
     }
-  ], function(err, lockIdMapping) {
-    if (err) { return callback(err); }
-    return callback(null, lockIdMapping);
-  });
+  ], callback);
 };
 
 /**

--- a/lib/lock.js
+++ b/lib/lock.js
@@ -47,12 +47,12 @@ exports.acquireLock = function(key, maximumLocks, ttlSeconds, callback) {
     function(cb) { return redis.ensureScript(client, lua.acquire_lock, cb); },
     function(cb) {
       client.eval(lua.acquire_lock, 1, key, lockId, maximumLocks, ttlSeconds, function(err, response) {
-        if (err) { return cb(err, null); }
+        if (err) { return cb(err); }
         return cb(null, response ? lockId : null);
       });
     }
   ], function(err, lockId) {
-    if (err) { return callback(err, null); }
+    if (err) { return callback(err); }
     return callback(null, lockId);
   });
 };
@@ -79,13 +79,13 @@ exports.acquireMultipleLocks = function(keys, maximumLocks, ttlSeconds, callback
     function(cb) { return redis.ensureScript(client, lua.acquire_multiple_locks, cb); },
     function(cb) {
       client.eval(evalArgs, function(err, response) {
-        if (err) { return cb(err, null); }
+        if (err) { return cb(err); }
         var lockIdMapping = _.object(keys, lockIds);
         return cb(null, response ? lockIdMapping : null);
       });
     }
   ], function(err, lockIdMapping) {
-    if (err) { return callback(err, null); }
+    if (err) { return callback(err); }
     return callback(null, lockIdMapping);
   });
 };

--- a/lib/redis-client.js
+++ b/lib/redis-client.js
@@ -1,3 +1,15 @@
 var config = require('./config');
-var client = require('redis').createClient(config.redis_port, config.redis_host);
-module.exports = client;
+var redisClient = require('redis').createClient(config.redis_port, config.redis_host);
+
+var loadedScriptStrings = {};
+
+exports.client = redisClient;
+
+exports.ensureScript = function(client, scriptString, cb) {
+  if (scriptString in loadedScriptStrings) { return cb(null); }
+  client.script('load', scriptString, function(err) {
+    if (err) { return cb(err); }
+    loadedScriptStrings[scriptString] = true;
+    return cb(null);
+  });
+};

--- a/lib/redis-client.js
+++ b/lib/redis-client.js
@@ -6,10 +6,10 @@ var loadedScriptStrings = {};
 exports.client = redisClient;
 
 exports.ensureScript = function(client, scriptString, cb) {
-  if (scriptString in loadedScriptStrings) { return cb(null); }
+  if (scriptString in loadedScriptStrings) { return cb(); }
   client.script('load', scriptString, function(err) {
     if (err) { return cb(err); }
     loadedScriptStrings[scriptString] = true;
-    return cb(null);
+    return cb();
   });
 };

--- a/test/lib/lock_test.js
+++ b/test/lib/lock_test.js
@@ -4,7 +4,7 @@ var _ = require('underscore');
 var uuid = require('node-uuid');
 var async = require('async');
 var lock = require('../../lib/lock');
-var client = require('../../lib/redis-client');
+var client = require('../../lib/redis-client').client;
 
 describe("The locking module", function() {
   var testKey = null;

--- a/test/lox_test.js
+++ b/test/lox_test.js
@@ -5,7 +5,7 @@ var uuid = require('node-uuid');
 
 var app = require('../lox');
 var config = require('../lib/config');
-var client = require('../lib/redis-client');
+var client = require('../lib/redis-client').client;
 
 describe("The HTTP endpoint", function() {
   var testKey = null;


### PR DESCRIPTION
@tleach The Node Redis driver actually attempts to use `evalsha` under the hood even if you call `eval`, though it falls back to normal `eval` if it can't find the script in the cache.