### PR TITLE
Use GET query args instead of POST-style message body for GET /lock

### DIFF
--- a/lox.js
+++ b/lox.js
@@ -44,16 +44,16 @@ app.get('/health', function(req, res) {
  */
 app.get('/lock', function(req, res) {
 
-  if (_.isUndefined(req.body.key)) {
+  if (_.isUndefined(req.query.key)) {
     return res.send(400);
   }
 
   async.series([
     function(callback) {
-      lock.reapLock(req.body.key, callback);
+      lock.reapLock(req.query.key, callback);
     },
     function(callback) {
-      lock.countLocks(req.body.key, function(err, count) {
+      lock.countLocks(req.query.key, function(err, count) {
         if (err) { return callback(err); }
         return res.status(200).json({heldLocks: count});
       });

--- a/test/lox_test.js
+++ b/test/lox_test.js
@@ -32,7 +32,7 @@ describe("The HTTP endpoint", function() {
     });
 
     it("returns 200 and a count against an empty lock", function(done) {
-      request(app).get('/lock').send({key: testKey})
+      request(app).get('/lock').query({key: testKey})
         .expect(200)
         .expect(function(res) {
           res.body.should.be.eql({heldLocks: 0});
@@ -44,7 +44,7 @@ describe("The HTTP endpoint", function() {
       var form = {key: testKey, maximumLocks: 1, ttlSeconds: 60};
       request(app).post('/lock').send(form).end(function(err, res) {
         if (err) { done(err); }
-        request(app).get('/lock').send({key: testKey})
+        request(app).get('/lock').query({key: testKey})
           .expect(200)
           .expect(function(res) {
             res.body.should.be.eql({heldLocks: 1});


### PR DESCRIPTION
review @thieman 

Right now the /lock endpoint, and the tests for it, are using POST style message body data. It will be more in line with expectation if it uses normal GET query args.